### PR TITLE
Rayon as an opt-out feature for multichannel processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,6 +660,7 @@ dependencies = [
  "num-traits",
  "rand 0.9.2",
  "rand_distr",
+ "rayon",
  "rustfft",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ repository = "https://github.com/wizenink/stft-rs"
 ndarray = "0.16.1"
 num-traits = "0.2"
 rustfft = "6.4.1"
+rayon = { version = "1.11", optional = true }
+
+[features]
+default = ["rayon"]
 
 [dev-dependencies]
 criterion = { version = "0.7.0", features = ["html_reports"] }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ High-quality, streaming-friendly STFT/iSTFT implementation in Rust working with 
 - **Multiple Window Functions**: Hann, Hamming, Blackman
 - **NOLA/COLA Validation**: Ensures reconstruction quality
 - **Flexible Buffer Management**: Three allocation strategies from simple to zero-allocation
-- **Multi-Channel Audio**: Process stereo, 5.1, 7.1+ with planar or interleaved formats
+- **Multi-Channel Audio**: Process stereo, 5.1, 7.1+ with planar or interleaved formats (parallelized with rayon)
 - **Generic Float Support**: Works with f32, f64, and other float types
 - **Type Aliases**: Convenient aliases like `StftConfigF32`, `BatchStftF32` for cleaner code
 - **Spectral Operations**: Built-in helpers for magnitude/phase manipulation, filtering, and custom processing
@@ -320,13 +320,13 @@ let filtered = istft.process(&spectrum);
 
 ## Multi-Channel Audio
 
-Process stereo, 5.1, or any channel count. Supports both planar and interleaved formats:
+Process stereo, 5.1, or any channel count. Channels are processed in parallel with rayon (enabled by default):
 
 ```rust
 // Planar: separate Vec per channel
 let left = vec![0.0; 44100];
 let right = vec![0.0; 44100];
-let spectra = stft.process_multichannel(&[left, right]);
+let spectra = stft.process_multichannel(&[left, right]); // Parallel with rayon
 
 // Interleaved: L,R,L,R...
 let interleaved = vec![0.0; 88200];
@@ -336,6 +336,8 @@ let spectra = stft.process_interleaved(&interleaved, 2);
 let channels = deinterleave(&interleaved, 2);
 let interleaved = interleave(&channels);
 ```
+
+Disable parallel processing: `cargo build --no-default-features`
 
 See `examples/multichannel_stereo.rs` and `examples/multichannel_midside.rs` for more.
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -13,10 +13,12 @@ cargo bench batch_benches
 cargo bench streaming_benches
 cargo bench spectral_benches
 cargo bench misc_benches
+cargo bench multichannel_benches
 
 # Run specific benchmark
 cargo bench batch_stft_only
 cargo bench allocation_strategies
+cargo bench multichannel
 
 # Save baseline for comparison
 cargo bench --bench stft-bench -- --save-baseline main
@@ -62,6 +64,12 @@ cargo bench --bench stft-bench -- --baseline main
 
 - **`padding_modes`** - Reflect, Zero, Edge padding
 - **`float_types`** - f32 vs f64 performance comparison
+
+### Multi-Channel (`multichannel_benches`)
+
+- **`multichannel`** - Multi-channel roundtrip (2, 4, 6, 8 channels)
+  - Parallelized with rayon (enabled by default)
+  - Benchmark with `--no-default-features` to test sequential processing
 
 ## Interpreting Results
 

--- a/tests/streaming_multichannel_tests.rs
+++ b/tests/streaming_multichannel_tests.rs
@@ -1,0 +1,168 @@
+use stft_rs::prelude::*;
+
+/// Generate a test sine wave
+fn generate_tone(freq: f32, duration_samples: usize, sample_rate: f32) -> Vec<f32> {
+    (0..duration_samples)
+        .map(|i| {
+            let t = i as f32 / sample_rate;
+            (2.0 * std::f32::consts::PI * freq * t).sin()
+        })
+        .collect()
+}
+
+#[test]
+fn test_multichannel_streaming_stft() {
+    let config = StftConfigF32::default_4096();
+    let mut stft = MultiChannelStreamingStftF32::new(config, 2);
+
+    assert_eq!(stft.num_channels(), 2);
+
+    // Push some samples
+    let left = vec![0.0; 512];
+    let right = vec![1.0; 512];
+
+    let frames = stft.push_samples(&[&left[..], &right[..]]);
+    assert_eq!(frames.len(), 2); // 2 channels
+}
+
+#[test]
+fn test_multichannel_streaming_roundtrip() {
+    let config = StftConfigF32::default_4096();
+    let mut stft = MultiChannelStreamingStftF32::new(config.clone(), 2);
+    let mut istft = MultiChannelStreamingIstftF32::new(config.clone(), 2);
+
+    let sample_rate = 44100.0;
+    let left = generate_tone(220.0, 4096, sample_rate);
+    let right = generate_tone(440.0, 4096, sample_rate);
+
+    // Process through STFT
+    let frames = stft.push_samples(&[&left[..], &right[..]]);
+
+    // Reconstruct through iSTFT
+    let mut output: Vec<Vec<f32>> = vec![Vec::new(), Vec::new()];
+
+    for i in 0..frames[0].len() {
+        let channel_frames: Vec<&SpectrumFrame<f32>> = (0..2).map(|ch| &frames[ch][i]).collect();
+        let samples = istft.push_frames(&channel_frames);
+        output[0].extend(&samples[0]);
+        output[1].extend(&samples[1]);
+    }
+
+    // Flush remaining
+    let flush_frames = stft.flush();
+    for i in 0..flush_frames[0].len() {
+        let channel_frames: Vec<&SpectrumFrame<f32>> =
+            (0..2).map(|ch| &flush_frames[ch][i]).collect();
+        let samples = istft.push_frames(&channel_frames);
+        output[0].extend(&samples[0]);
+        output[1].extend(&samples[1]);
+    }
+
+    let flush_samples = istft.flush();
+    output[0].extend(&flush_samples[0]);
+    output[1].extend(&flush_samples[1]);
+
+    // Basic sanity checks
+    assert!(output[0].len() > 3000);
+    assert!(output[1].len() > 3000);
+}
+
+#[test]
+fn test_multichannel_streaming_stereo() {
+    let config = StftConfigF32::default_4096();
+    let mut stft = MultiChannelStreamingStftF32::new(config.clone(), 2);
+    let mut istft = MultiChannelStreamingIstftF32::new(config, 2);
+
+    let chunk_size = 512;
+    let left = vec![0.5; chunk_size * 10];
+    let right = vec![-0.5; chunk_size * 10];
+
+    let mut output: Vec<Vec<f32>> = vec![Vec::new(), Vec::new()];
+
+    // Process in chunks
+    for i in 0..10 {
+        let left_chunk = &left[i * chunk_size..(i + 1) * chunk_size];
+        let right_chunk = &right[i * chunk_size..(i + 1) * chunk_size];
+
+        let frames = stft.push_samples(&[left_chunk, right_chunk]);
+
+        for frame_idx in 0..frames[0].len() {
+            let channel_frames: Vec<&SpectrumFrame<f32>> =
+                (0..2).map(|ch| &frames[ch][frame_idx]).collect();
+            let samples = istft.push_frames(&channel_frames);
+            output[0].extend(&samples[0]);
+            output[1].extend(&samples[1]);
+        }
+    }
+
+    // Flush
+    let flush_frames = stft.flush();
+    for i in 0..flush_frames[0].len() {
+        let channel_frames: Vec<&SpectrumFrame<f32>> =
+            (0..2).map(|ch| &flush_frames[ch][i]).collect();
+        let samples = istft.push_frames(&channel_frames);
+        output[0].extend(&samples[0]);
+        output[1].extend(&samples[1]);
+    }
+
+    let flush_samples = istft.flush();
+    output[0].extend(&flush_samples[0]);
+    output[1].extend(&flush_samples[1]);
+
+    // Channels should be independent
+    assert!(output[0].len() > 4000);
+    assert!(output[1].len() > 4000);
+}
+
+#[test]
+fn test_multichannel_streaming_reset() {
+    let config = StftConfigF32::default_4096();
+    let mut stft = MultiChannelStreamingStftF32::new(config.clone(), 2);
+
+    let left = vec![0.0; 512];
+    let right = vec![1.0; 512];
+
+    let frames1 = stft.push_samples(&[&left[..], &right[..]]);
+
+    stft.reset();
+
+    let frames2 = stft.push_samples(&[&left[..], &right[..]]);
+
+    // After reset, should produce same results
+    assert_eq!(frames1[0].len(), frames2[0].len());
+    assert_eq!(frames1[1].len(), frames2[1].len());
+}
+
+#[test]
+fn test_multichannel_streaming_quad() {
+    let config = StftConfigF32::default_4096();
+    let mut stft = MultiChannelStreamingStftF32::new(config.clone(), 4);
+
+    assert_eq!(stft.num_channels(), 4);
+
+    let channels: Vec<Vec<f32>> = (0..4).map(|_| vec![0.0; 512]).collect();
+    let channel_refs: Vec<&[f32]> = channels.iter().map(|c| c.as_slice()).collect();
+
+    let frames = stft.push_samples(&channel_refs);
+    assert_eq!(frames.len(), 4);
+}
+
+#[test]
+#[should_panic(expected = "Expected 2 channels, got 3")]
+fn test_multichannel_streaming_wrong_channel_count() {
+    let config = StftConfigF32::default_4096();
+    let mut stft = MultiChannelStreamingStftF32::new(config, 2);
+
+    let ch1 = vec![0.0; 512];
+    let ch2 = vec![0.0; 512];
+    let ch3 = vec![0.0; 512];
+
+    stft.push_samples(&[&ch1[..], &ch2[..], &ch3[..]]);
+}
+
+#[test]
+#[should_panic(expected = "num_channels must be > 0")]
+fn test_multichannel_streaming_zero_channels() {
+    let config = StftConfigF32::default_4096();
+    let _stft = MultiChannelStreamingStftF32::new(config, 0);
+}


### PR DESCRIPTION
Rayon now is a dependency gated behind a default feature, used for parallelization of multi-channel waves