### PR TITLE
Only check whether fft is power of two when not using rustfft-backend

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,21 +361,21 @@ fn generate_window<T: Float + FromPrimitive>(window_type: WindowType, size: usiz
                 let half = T::from(0.5).unwrap();
                 let one = T::one();
                 let i_t = T::from(i).unwrap();
-                let size_t = T::from(size).unwrap();  // Use N, not N-1 for periodic window
+                let size_t = T::from(size).unwrap(); // Use N, not N-1 for periodic window
                 half * (one - (two * pi * i_t / size_t).cos())
             })
             .collect(),
         WindowType::Hamming => (0..size)
             .map(|i| {
                 let i_t = T::from(i).unwrap();
-                let size_t = T::from(size).unwrap();  // Use N, not N-1 for periodic window
+                let size_t = T::from(size).unwrap(); // Use N, not N-1 for periodic window
                 T::from(0.54).unwrap() - T::from(0.46).unwrap() * (two * pi * i_t / size_t).cos()
             })
             .collect(),
         WindowType::Blackman => (0..size)
             .map(|i| {
                 let i_t = T::from(i).unwrap();
-                let size_t = T::from(size).unwrap();  // Use N, not N-1 for periodic window
+                let size_t = T::from(size).unwrap(); // Use N, not N-1 for periodic window
                 let angle = two * pi * i_t / size_t;
                 T::from(0.42).unwrap() - T::from(0.5).unwrap() * angle.cos()
                     + T::from(0.08).unwrap() * (two * angle).cos()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@ impl<T: Float + FromPrimitive + fmt::Debug> StftConfig<T> {
         window: WindowType,
         reconstruction_mode: ReconstructionMode,
     ) -> Result<Self, ConfigError<T>> {
-        if fft_size == 0 || !fft_size.is_power_of_two() {
+        if fft_size == 0 || !(cfg!(feature = "rustfft-backend") || fft_size.is_power_of_two()) {
             return Err(ConfigError::InvalidFftSize);
         }
         if hop_size == 0 || hop_size > fft_size {

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -26,17 +26,25 @@ fn test_config_invalid_ola() {
 #[allow(deprecated)]
 fn test_config_invalid_fft_size() {
     let config = StftConfig::<f32>::new(4095, 1024, WindowType::Hann, ReconstructionMode::Ola);
-    assert!(matches!(config, Err(_)));
+    assert!(config.is_err());
+}
+
+#[cfg(feature = "rustfft-backend")]
+#[test]
+#[allow(deprecated)]
+fn test_config_fft_size_not_power_of_two() {
+    let config = StftConfig::<f32>::new(4095, 1024, WindowType::Hann, ReconstructionMode::Ola);
+    assert!(config.is_ok());
 }
 
 #[test]
 #[allow(deprecated)]
 fn test_config_invalid_hop_size() {
     let config = StftConfig::<f32>::new(4096, 0, WindowType::Hann, ReconstructionMode::Ola);
-    assert!(matches!(config, Err(_)));
+    assert!(config.is_err());
 
     let config = StftConfig::<f32>::new(4096, 5000, WindowType::Hann, ReconstructionMode::Ola);
-    assert!(matches!(config, Err(_)));
+    assert!(config.is_err());
 }
 
 // Builder pattern tests
@@ -76,17 +84,13 @@ fn test_builder_with_reconstruction_mode() {
 
 #[test]
 fn test_builder_missing_fft_size() {
-    let config = StftConfig::<f32>::builder()
-        .hop_size(1024)
-        .build();
+    let config = StftConfig::<f32>::builder().hop_size(1024).build();
     assert!(config.is_err());
 }
 
 #[test]
 fn test_builder_missing_hop_size() {
-    let config = StftConfig::<f32>::builder()
-        .fft_size(4096)
-        .build();
+    let config = StftConfig::<f32>::builder().fft_size(4096).build();
     assert!(config.is_err());
 }
 
@@ -98,6 +102,16 @@ fn test_builder_invalid_fft_size() {
         .hop_size(1024)
         .build();
     assert!(config.is_err());
+}
+
+#[cfg(feature = "rustfft-backend")]
+#[test]
+fn test_builder_fft_size_not_power_of_two() {
+    let config = StftConfig::<f32>::builder()
+        .fft_size(4095) // Not a power of 2
+        .hop_size(1024)
+        .build();
+    assert!(config.is_ok());
 }
 
 #[test]

--- a/tests/config_tests.rs
+++ b/tests/config_tests.rs
@@ -21,6 +21,7 @@ fn test_config_invalid_ola() {
     assert!(config.is_err())
 }
 
+#[cfg(not(feature = "rustfft-backend"))]
 #[test]
 #[allow(deprecated)]
 fn test_config_invalid_fft_size() {
@@ -89,6 +90,7 @@ fn test_builder_missing_hop_size() {
     assert!(config.is_err());
 }
 
+#[cfg(not(feature = "rustfft-backend"))]
 #[test]
 fn test_builder_invalid_fft_size() {
     let config = StftConfig::<f32>::builder()


### PR DESCRIPTION
Resolves #18 